### PR TITLE
Add variable for active playlist item names

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -603,8 +603,14 @@ class ModuleInstance extends InstanceBase<DeviceConfig> {
 				active_presentation_playlist_uuid: statusJSONObject.data.presentation.playlist.uuid,
 			})
 			const activePlaylistItemsResponse: RequestAndResponseJSONValue = await this.ProPresenter.playlistPlaylistIdGet(statusJSONObject.data.presentation.playlist.uuid)
-			if (activePlaylistItemsResponse.ok)
+			if (activePlaylistItemsResponse.ok) {
 				SetVariableValues(this, {active_presentation_playlist_json: JSON.stringify(activePlaylistItemsResponse.data.items)})
+				SetVariableValues(this, {
+					active_presentation_playlist_item_names: activePlaylistItemsResponse.data.items.map(
+						(a: { id: { name: string } }) => a.id.name
+					),
+				})
+			}
 		} else {
 			SetVariableValues(this, {
 				active_presentation_playlist_name: '',

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -176,6 +176,10 @@ export function GetVariableDefinitions(propresenterStateStore: ProPresenterState
 		variableId: 'active_presentation_playlist_json',
 	})
 	variables.push({
+		name: 'Active Presentation Playlist Item Names',
+		variableId: 'active_presentation_playlist_item_names',
+	})
+	variables.push({
 		name: 'Focused Playlist Items JSON',
 		variableId: 'focused_playlist_items_json',
 	})


### PR DESCRIPTION
Adds a simple list/array variable for items in the currently active presentation playlist.

$(propres:active_presentation_playlist_item_names) | Active Presentation Playlist Item Names | Holy Forever,I Believe,Magnify,sermon test
-- | -- | --
