### PR TITLE
fix: add extra uuid check for ProTimers

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -914,6 +914,7 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 				const thisProTimerState = instance.propresenterStateStore.proTimers.find(
 					(proTimerState) =>
 						proTimerState.id.uuid == timerID ||
+						proTimerState.id.uuid.replace(/-/g, '') == timerID ||
 						proTimerState.id.name == timerID ||
 						proTimerState.id.index == parseInt(timerID)
 				)

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -511,7 +511,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 				return (
 					instance.propresenterStateStore.proTimers.find(
 						(proTimer) =>
-							proTimer.id.uuid == timer_id || proTimer.id.name == timer_id || proTimer.id.index == parseInt(timer_id)
+							proTimer.id.uuid == timer_id || proTimerState.id.uuid.replace(/-/g, '') == timerID || proTimer.id.name == timer_id || proTimer.id.index == parseInt(timer_id)
 					)?.state == feedback.options.timer_state
 				)
 			},


### PR DESCRIPTION
In [main.ts](https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/main.ts) when setting the internal variables they are set using UUID4 strings with the dash ('-') removed.

https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/main.ts#L499-L506

https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/main.ts#L531-L543

Timer Operations in [actions.ts](https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/actions.ts) check against the UUID, name, or index. 

https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/actions.ts#L914-L919

This may be confusing for some users if they try and use these operations based on the IDs shown in the variable names without adding the dash ('-') back in.

While they can remake the UUID4 with companion functions,
```
concat(substr($(custom:timer_ID),0,8),"-",substr($(custom:timer_ID),8,12),"-",substr($(custom:gtimer_ID),12,16),"-",substr($(custom:timer_ID),16,20),"-",substr($(custom:timer_ID),20))
```

it would be great if the module respects that it has made a change to the UUID that it shows the user and accounts for that in it's search.

```js
 const thisProTimerState = instance.propresenterStateStore.proTimers.find( 
 	(proTimerState) => 
 		proTimerState.id.uuid == timerID || 
 		proTimerState.id.uuid.replace(/-/g, '') == timerID ||
 		proTimerState.id.name == timerID || 
 		proTimerState.id.index == parseInt(timerID) 
 ) 
```

Similar for [feedbacks.ts](https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/feedbacks.ts).

https://github.com/bitfocus/companion-module-renewedvision-propresenter-api/blob/bc10dc208fa2ccae6a3ebac2d7232e4689e563fa/src/feedbacks.ts#L511-L516

```js
 return ( 
 	instance.propresenterStateStore.proTimers.find( 
 		(proTimer) => 
 			proTimer.id.uuid == timer_id || proTimerState.id.uuid.replace(/-/g, '') == timerID || proTimer.id.name == timer_id || proTimer.id.index == parseInt(timer_id) 
 	)?.state == feedback.options.timer_state 
 ) 
```