### PR TITLE
fix: rename Stage Display to Stage Message in operation action (#92)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -816,9 +816,9 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 			},
 		},
 		// **** STAGE ****
-		[ActionId.stageDisplayOperation]: {
-			name: 'Stage Display: Operation',
-			description: 'Perform an operation on the stage display',
+		[ActionId.stageMessageOperation]: {
+			name: 'Stage Message: Operation',
+			description: 'Perform an operation on the stage message',
 			options: [
 				options.stagedisplay_operation,
 				options.stage_message_text,
@@ -1200,7 +1200,7 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 	timerChoicesDropDown.default = timerChoicesDropDown.choices[0].id
 
 	// Update stagescreen choices with data from propresenterStateStore
-	const stageScreenChoicesDropDown = actions[ActionId.stageDisplayOperation]?.options[2] as CompanionInputFieldDropdown
+	const stageScreenChoicesDropDown = actions[ActionId.stageMessageOperation]?.options[2] as CompanionInputFieldDropdown
 	const manual_stagescreen_choice = stageScreenChoicesDropDown.choices.pop() // The last item in the stage screen choices list (after all the current stage screens list from ProPresenter) is a placeholder, that when selected, allows for manually specifing the stage screen (in another text input)
 	stageScreenChoicesDropDown.choices = instance.propresenterStateStore.stageScreenChoices.concat(
 		manual_stagescreen_choice as DropdownChoice
@@ -1208,7 +1208,7 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 	stageScreenChoicesDropDown.default = stageScreenChoicesDropDown.choices[0].id
 
 	// Update stagescreen layout choices with data from propresenterStateStore
-	const stageScreenLayoutChoicesDropDown = actions[ActionId.stageDisplayOperation]
+	const stageScreenLayoutChoicesDropDown = actions[ActionId.stageMessageOperation]
 		?.options[4] as CompanionInputFieldDropdown
 	const manual_stagescreenlayout_choice = stageScreenLayoutChoicesDropDown.choices.pop() // The last item in the stage screen layout choices list (after all the current stage screen layouts list from ProPresenter) is a placeholder, that when selected, allows for manually specifing the stage screen layout (in another text input)
 	stageScreenLayoutChoicesDropDown.choices = instance.propresenterStateStore.stageScreenLayoutChoices.concat(
@@ -1307,7 +1307,7 @@ export enum ActionId {
 	propOperation = 'propOperation',
 
 	// Stage
-	stageDisplayOperation = 'stageDisplayOperation',
+	stageMessageOperation = 'stageMessageOperation',
 
 	// Screens
 	screensOperation = 'screensOperation',

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1869,7 +1869,7 @@ export function GetPresets(instance: InstanceBaseExt<DeviceConfig>): CompanionPr
 				{
 					down: [
 						{
-							actionId: ActionId.stageDisplayOperation,
+							actionId: ActionId.stageMessageOperation,
 							options: { stagedisplay_operation: 'toggle_stage_message', stage_message_text: 'Okay' },
 						},
 					],
@@ -1922,11 +1922,11 @@ export function GetPresets(instance: InstanceBaseExt<DeviceConfig>): CompanionPr
 				{
 					down: [
 						{
-							actionId: ActionId.stageDisplayOperation,
+							actionId: ActionId.stageMessageOperation,
 							options: { stagedisplay_operation: 'show_stage_message', stage_message_text: 'Okay' },
 						},
 						{
-							actionId: ActionId.stageDisplayOperation,
+							actionId: ActionId.stageMessageOperation,
 							options: { stagedisplay_operation: 'hide_stage_message', stage_message_text: 'Okay' },
 							delay: 5000,
 						},
@@ -3648,7 +3648,7 @@ export function GetPresets(instance: InstanceBaseExt<DeviceConfig>): CompanionPr
 					{
 						down: [
 							{
-								actionId: ActionId.stageDisplayOperation,
+								actionId: ActionId.stageMessageOperation,
 								options: {
 									stagedisplay_operation: 'set_layout',
 									stagescreen_id_dropdown: stage_screen_id,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -477,8 +477,8 @@ export const options: Options = {
 	},
 	stagedisplay_operation: {
 		type: 'dropdown',
-		label: 'Stage Display: Operation',
-		tooltip: 'Choose an operation to perform on a stage display',
+		label: 'Stage Message: Operation',
+		tooltip: 'Choose an operation to perform on a stage message',
 		id: 'stagedisplay_operation',
 		choices: [
 			{ id: 'show_stage_message', label: 'Show Stage Message' },


### PR DESCRIPTION
## Summary

This PR renames `ActionId.stageDisplayOperation` → `ActionId.stageMessageOperation` and updates the action label/description from "Stage Display" to "Stage Message" to accurately reflect the Stage Message operations this action performs (show/hide/toggle stage messages).

### Changes

- **Enum**: `stageDisplayOperation` → `stageMessageOperation` (ActionId string: `'stageMessageOperation'`)
- **Action name**: "Stage Display: Operation" → "Stage Message: Operation"  
- **Action description**: "Perform an operation on the stage display" → "Perform an operation on the stage message"
- **Dropdown label**: "Stage Display: Operation" → "Stage Message: Operation" (utils.ts)
- **Dropdown tooltip**: "Choose an operation to perform on a stage display" → "Choose an operation to perform on a stage message"
- **Presets**: All `ActionId.stageDisplayOperation` references updated to `ActionId.stageMessageOperation`

### Rationale

The action's dropdown choices are all Stage Message operations ("Show Stage Message", "Hide Stage Message", "Toggle Stage Message"), making "Stage Message: Operation" the correct label. The label previously said "Stage Display" despite the action being about Stage Messages.

Fixes #92.