### PR TITLE
Fix parseInt/UUID collision in ID lookup (timers, props, stage screens, looks)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -802,7 +802,9 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 						if (
 							instance.propresenterStateStore.proProps.find(
 								(proProp) =>
-									proProp.id.uuid == prop_id || proProp.id.name == prop_id || proProp.id.index == parseInt(prop_id)
+									proProp.id.uuid == prop_id ||
+									proProp.id.name == prop_id ||
+									(/^\d+$/.test(prop_id) && proProp.id.index == parseInt(prop_id))
 							)?.is_active == true
 						) {
 							await instance.ProPresenter.propIdClear(prop_id)
@@ -932,7 +934,7 @@ export function GetActions(instance: InstanceBaseExt<DeviceConfig>): CompanionAc
 						proTimerState.id.uuid == timerID ||
 						proTimerState.id.uuid.replace(/-/g, '') == timerID ||
 						proTimerState.id.name == timerID ||
-						proTimerState.id.index == parseInt(timerID)
+						(/^\d+$/.test(timerID) && proTimerState.id.index == parseInt(timerID))
 				)
 
 				// Determine action to "toggle" current timer state

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -190,7 +190,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 						(stageScreenWithLayout) =>
 							stageScreenWithLayout.id.uuid == stage_screen_id ||
 							stageScreenWithLayout.id.name == stage_screen_id ||
-							stageScreenWithLayout.id.index == parseInt(stage_screen_id)
+							(/^\d+$/.test(stage_screen_id) && stageScreenWithLayout.id.index == parseInt(stage_screen_id))
 					)
 				if (selected_stage_screen == undefined) {
 					return false // Can't find specified stage screen
@@ -198,7 +198,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 					return (
 						selected_stage_screen.layout_uuid == stage_layout_id ||
 						selected_stage_screen.layout_name == stage_layout_id ||
-						selected_stage_screen.layout_index == parseInt(stage_layout_id)
+						(/^\d+$/.test(stage_layout_id) && selected_stage_screen.layout_index == parseInt(stage_layout_id))
 					)
 				}
 			},
@@ -378,7 +378,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 					)
 
 				return (
-					instance.propresenterStateStore.activeLookID.index == parseInt(look_id) ||
+					(/^\d+$/.test(look_id) && instance.propresenterStateStore.activeLookID.index == parseInt(look_id)) ||
 					instance.propresenterStateStore.activeLookID.uuid == look_id ||
 					instance.propresenterStateStore.activeLookID.name == look_id
 				)
@@ -425,7 +425,9 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 				return (
 					instance.propresenterStateStore.proProps.find(
 						(proProp) =>
-							proProp.id.uuid == prop_id || proProp.id.name == prop_id || proProp.id.index == parseInt(prop_id)
+							proProp.id.uuid == prop_id ||
+							proProp.id.name == prop_id ||
+							(/^\d+$/.test(prop_id) && proProp.id.index == parseInt(prop_id))
 					)?.is_active == true
 				)
 			},
@@ -514,7 +516,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<DeviceConfig>): Companion
 							proTimer.id.uuid == timer_id ||
 							proTimer.id.uuid.replace(/-/g, '') == timer_id ||
 							proTimer.id.name == timer_id ||
-							proTimer.id.index == parseInt(timer_id)
+							(/^\d+$/.test(timer_id) && proTimer.id.index == parseInt(timer_id))
 					)?.state == feedback.options.timer_state
 				)
 			},


### PR DESCRIPTION
## Summary

`parseInt()` parses leading digits and stops at the first non-digit character instead of returning `NaN` for a non-numeric string. Several ID-lookup callbacks use an OR-chain like:

```ts
proTimer.id.uuid == timer_id ||
proTimer.id.name == timer_id ||
proTimer.id.index == parseInt(timer_id)
```

If `timer_id` is a UUID that starts with one or more digits (e.g. `0FA9B6FF-7572-4237-BE5F-5F5C08EA0009`), `parseInt(timer_id)` silently returns `0` instead of `NaN`. If another item in the same list happens to have numeric `index === 0` and appears earlier in the array, `Array.prototype.find()` returns that *other* item instead of the intended one.

### Observed symptom (5-timer setup)

With timers `Praise` (index 0), `Letzter Song` (index 1), `VdP` (index 2), `Reaction` (index 3), `Uplifter` (index 4):

- Starting **Uplifter** (UUID starts with `0`) made the **Praise** "Timer State" feedback show Running instead.
- Starting **Reaction** (UUID starts with `2`) made the **VdP** "Timer State" feedback show Running instead.
- Timers whose UUID happens to start with a letter (Praise, Letzter Song, VdP) were unaffected, because `parseInt()` returns `NaN` for those and `NaN == x` is always `false` — which is why the bug looked timer-specific at first.

The same OR-chain pattern (and therefore the same class of bug) exists at 4 additional non-timer sites, all fixed here for consistency:
- Prop Active feedback / Prop toggle action (`prop_id`)
- Stage Screen feedback (`stage_screen_id`, `stage_layout_id`)
- Active Look feedback (`look_id`)

## Fix

Guard the index-comparison branch so it only runs when the id is actually purely numeric:

```diff
- proTimer.id.index == parseInt(timer_id)
+ (/^\d+$/.test(timer_id) && proTimer.id.index == parseInt(timer_id))
```

This preserves the original intent of allowing lookup by numeric index, while no longer letting a UUID's leading digits masquerade as an index.

## Test plan

- [x] `tsc -p tsconfig.build.json` compiles with no errors
- [x] Standalone Node script replicating the exact `.find()` predicates, run against 5 real timer UUIDs (`FD09B27A…`, `FAE7F035…`, `B9E19B74…`, `2ECACD59…`, `0FA9B6FF…`) plus synthetic digit-leading UUIDs for props/stage screens/looks — confirms each id now resolves to itself, and reproduces the original misrouting (Uplifter→Praise, Reaction→VdP) when run against the old unguarded logic for comparison
- [ ] Manual confirmation in Companion with a live ProPresenter instance (reporter has verified the timer fix locally; happy to have this re-tested by a maintainer or additional reporter before merge)